### PR TITLE
fix html proofer to ignore libera links

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,5 +50,6 @@ jobs:
           URL_IGNORE="$URL_IGNORE,/^https:\/\/github.com\/kiali\/kiali\/issues\/\d+/"
           URL_IGNORE="$URL_IGNORE,/^https:\/\/github.com\/kiali\/kiali\/tree\/v\d+\.\d+\//"
           URL_IGNORE="$URL_IGNORE,/^https:\/\/github.com\/kiali\/kiali\/blob\/v\d+\.\d+\//"
+          URL_IGNORE="$URL_IGNORE,/.*web.libera.chat.*/"
           htmlproofer --assume-extension --check-external-hash --empty_alt_ignore --url-ignore "$URL_IGNORE" ./public
 

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,6 @@ VERSION ?= v1.36.0
 HUGO_VERSION ?= 0.53
 CONTAINER_RUNTIME ?= docker
 
-# muffet - checks for broken links - you have to have hugo running for this to work
-muffet:
-	@if ! curl -s --fail http://localhost:1313 > /dev/null ; then echo "You must start a Hugo local server!"; exit 1; fi
-	@mkdir -p $(CURDIR)/output/muffet
-	@ if [ ! -f $(CURDIR)/output/muffet/bin/muffet ] ; then GOPATH=$(CURDIR)/output/muffet go get -u github.com/raviqqe/muffet; fi
-	@$(CURDIR)/output/muffet/bin/muffet --exclude \#\!\(forum\|msg\)\/kiali-\(dev\|users\)\/? --exclude https?:\/\/localhost:20001\/? --exclude \/documentation\/developer-api --exclude libera http://localhost:1313/
-
 # This is not supposed to be run locally, prefer using `serve` instead.
 build:
 	gem install asciidoctor -v 1.5.6.1


### PR DESCRIPTION
Ignore the web.libera.chat urls.

This also removes the muffet target - that was broke - tons of errors getting spit out. Seems that has deteriorated and since no one uses it for anything, let's just remove it to avoid confusion. It confused me because that is what I thought github CI was using to check the links, but it was not using it at all.